### PR TITLE
fix: incompat with epsilon mainboard and thermald.

### DIFF
--- a/home/slwst/packages.nix
+++ b/home/slwst/packages.nix
@@ -9,6 +9,8 @@
     alsa-tools
     alsa-utils
 
+    gsettings-desktop-schemas
+    appimage-run
     bandwhich
     blender
     bottles
@@ -17,19 +19,26 @@
     cinnamon.nemo
     coreutils
     dconf
+    d2
     fd
     ffmpeg-full
     gimp
+    github-desktop
+    gitkraken
     glava
     glib
     glxinfo
     gnome.gucharmap
     gnome.gnome-power-manager
+    goverlay
+    google-cloud-sdk
     imagemagick
     jq
+    libpng
     license-generator
     lm_sensors
     lutris
+    mangohud
     mpv
     neo
     neofetch
@@ -42,14 +51,19 @@
     protonup
     pulseaudio
     psmisc
+    razergenie
     ripgrep
     rsync
     session-desktop
     spotifywm
+    strace
+    stress
+    s-tui
     tree
     ttyper
     unzip
     viu
+    xdg-user-dirs
     xdg-utils
     yubikey-manager
     yubikey-manager-qt

--- a/hosts/epsilon/default.nix
+++ b/hosts/epsilon/default.nix
@@ -29,6 +29,7 @@
       package = pkgs.bluez;
     };
     i2c.enable = true;
+    openrazer.enable = true;
 
     pulseaudio.enable = false;
   };
@@ -36,7 +37,7 @@
   services = {
     btrfs.autoScrub.enable = true;
     acpid.enable = true;
-    thermald.enable = true;
+    #thermald.enable = true;
     upower.enable = true;
     hardware.openrgb = {
       enable = true;

--- a/hosts/shared/environment/systemPackages.nix
+++ b/hosts/shared/environment/systemPackages.nix
@@ -5,6 +5,7 @@
     git
     hddtemp
     jq
+    file
     kitty #for terminfo
     lm_sensors
     pciutils

--- a/hosts/shared/services/openssh.nix
+++ b/hosts/shared/services/openssh.nix
@@ -7,7 +7,6 @@
   services.openssh = {
     enable = true;
     openFirewall = true;
-    forwardX11 = false;
     ports = [22];
     banner = ''
       ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣶⠖⢶⣦⣄⡀⠀⢀⣴⣶⠟⠓⣶⣦⣄⡀⠀⠀⠀⠀⠀⣀⣤⣤⣀⡀⠀⠀⢠⣤⣤⣄⡀⠀⠀⠀⠀⠀
@@ -36,6 +35,7 @@
 
     '';
     settings = {
+      X11Forwarding = false;
       kbdInteractiveAuthentication = false;
       passwordAuthentication = lib.mkForce false;
       permitRootLogin = lib.mkForce "no";

--- a/hosts/shared/users.nix
+++ b/hosts/shared/users.nix
@@ -25,6 +25,7 @@ in {
         "docker"
         "git"
         "libvirtd"
+        "openrazer"
       ];
     openssh.authorizedKeys.keys = [
       "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9vuN/AfJ46kG8b1fPaDevQQcPmoP6Nsx8VB02o5w2qbSTyqEgqRRikLDvNtVaTDzPbiiXUzPebvB4VwVOlvKb7mg1GQhzrS7s1lc5j0IIpxEwKAolTb0tgn0W5KYRHwsILBUaplvL/mGVVV9OltuCdSjE12hPHuC/nlXcjbJKpHaLrF0nltAunMwIStw6inK8fXQnISpDRtGAcVkiN/voaCVCYRctVJvir0y4ZeTj9E3jceLygdXR0G74UxdJLKi5k6x0d1eln0Z7a6Q+AnuA5rBM6Oi4gsWZcqGXHCxRLLd1/qa3P2dSOW0FlXdGbQcTfE1tEFhuD41RR6n27hXBVfXOJOnyT1X+cHv/74BD6J1bYCyzDxCUi3dYmYEZPZJWuPoISyAXFK3pvKhRwEjhIX+2HbypMNiKnELOX6w5mvcOID4D+415w8Vi9hIDsDuUWrFFeuJN48j9YDvE8EPEeXfyUnQBUNLHL05Rwi8hOC7mXtJeEW6Lyh86VCbAMLZOi5gz/FgEHNLwfBBsJjADWD8rMgf64MiynIoOculk/GAytD6dLixzO9AcvW5Sh/t+36G0M2OxHjABYkBilCzllIrg9+VJ7qfsIouOdzU88lpbOyoDiExmeyAXBU4KtmywXmwfg6uPjymqOshGij5QYvg3bZncyGTFgVLtw/0SNQ== cardno:000609728578"

--- a/modules/nixos/hardware/nvidia.nix
+++ b/modules/nixos/hardware/nvidia.nix
@@ -38,6 +38,9 @@ in {
         modesetting.enable = true;
         powerManagement.enable = true;
 
+        # should be one release behind latest or stable
+        package = config.boot.kernelPackages.nvidiaPackages.production;
+
         # experimental
         open = false;
       };

--- a/modules/nixos/steam/default.nix
+++ b/modules/nixos/steam/default.nix
@@ -17,6 +17,7 @@ in {
       remotePlay.openFirewall = true;
       dedicatedServer.openFirewall = false;
     };
+    programs.gamemode.enable = true;
 
     environment = {
       sessionVariables = rec {
@@ -29,7 +30,7 @@ in {
       systemPackages = with pkgs; [
         nspr # albion
         protonup
-        gamemode
+        #        gamemode
         SDL2
       ];
     };


### PR DESCRIPTION
 Two thermal scaling solutions were vying for the same resources, elected to keep the hardware solution in place.  Nvidia driver is now pinned to the `production` package.  In unstable nixos packages repo, both `stable` and `latest` appear to be the bleeding edge version, with `production` being one release behind.